### PR TITLE
docker change: include repo in volume

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,4 @@
-version: '3.8'
+version: "3.8"
 
 services:
   app:
@@ -8,4 +8,4 @@ services:
     command: ["--create_csv"]
     tty: true
     volumes:
-      - ./private/output:/private/output
+      - .:/src


### PR DESCRIPTION
### What are the relevant tickets?
None

### Description (What does it do?)
Adds the repo to docker volumes so we can test changes without rebuilding.  Currently, changing python files requires rebuilding docker.

### How can this be tested?
1. Edit a python file...e.g., add `print('Hello, world!')` to the top of `create_csv` function.
2. Run docker compose up

you should see the change take effect immediately, without needing to rebuild.
