### PR TITLE
Update API_BASE_URL to reflect new MITOpen API Endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ If you want to change this, you will not only have to change the `output_path` i
 
 By default, this project uses MIT Open's Production API, as given in `ocw_oer_export/config.py`.
 To use the RC API or local, create an environment file, `.env` in the project's root directory and add the relevant base URL:
-Eg. `API_BASE_URL=https://api.mitopen-rc.odl.mit.edu` or `API_BASE_URL=http://localhost:8063`
+e.g., `API_BASE_URL=https://api.mitopen-rc.odl.mit.edu` or `API_BASE_URL=http://localhost:8063`
 
 ## Requirements
 

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ If you want to change this, you will not only have to change the `output_path` i
 
 By default, this project uses MIT Open's Production API, as given in `ocw_oer_export/config.py`.
 To use the RC API or local, create an environment file, `.env` in the project's root directory and add the relevant base URL:
-Eg. `API_BASE_URL=https://mitopen-rc.odl.mit.edu` or `API_BASE_URL=http://localhost:8063`
+Eg. `API_BASE_URL=https://api.mitopen-rc.odl.mit.edu` or `API_BASE_URL=http://localhost:8063`
 
 ## Requirements
 

--- a/ocw_oer_export/config.py
+++ b/ocw_oer_export/config.py
@@ -7,5 +7,5 @@ from dotenv import load_dotenv
 
 load_dotenv()
 
-API_BASE_URL = os.getenv("API_BASE_URL", "https://mitopen.odl.mit.edu")
+API_BASE_URL = os.getenv("API_BASE_URL", "https://api.mitopen.odl.mit.edu")
 API_URL = f"{API_BASE_URL}/api/v1/courses/?platform=ocw"


### PR DESCRIPTION
### What are the relevant tickets?
No ticket

### Description (What does it do?)
MITOpen has updated its API endpoint, changing the base URL from `https://mitopen.odl.mit.edu` to `https://api.mitopen.odl.mit.edu`. This was a breaking change for `ocw_oer_export`.

This PR updates the `API_BASE_URL` from config.

### How can this be tested?
1. docker compose build
2. docker compose run --rm app
3. Locate the file `private/output/ocw_oer_export.csv` and see it has OCW courses data.

