### PR TITLE
Update: Switch all references from MIT Open to MIT Learn

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # OCW OER Export
 
-This demonstration project showcases how to utilize the MIT Open API. It specifically focuses on extracting MIT OpenCourseWare courses' metadata and creating a CSV file for export to OER Commons, aligning with their specific [requirements](https://help.oercommons.org/support/solutions/articles/42000046853-import-resources-with-the-bulk-import-template).
+This demonstration project showcases how to utilize the MIT Learn API. It specifically focuses on extracting MIT OpenCourseWare courses' metadata and creating a CSV file for export to OER Commons, aligning with their specific [requirements](https://help.oercommons.org/support/solutions/articles/42000046853-import-resources-with-the-bulk-import-template).
 
 **SECTIONS**
 
@@ -46,13 +46,13 @@ If you want to change this, you will not only have to change the `output_path` i
 
 ## Environment Variables
 
-By default, this project uses MIT Open's Production API, as given in `ocw_oer_export/config.py`.
+By default, this project uses MIT Learn's Production API, as given in `ocw_oer_export/config.py`.
 To use the RC API or local, create an environment file, `.env` in the project's root directory and add the relevant base URL:
-e.g., `API_BASE_URL=https://api.mitopen-rc.odl.mit.edu` or `API_BASE_URL=http://localhost:8063`
+e.g., `API_BASE_URL=https://api.rc.learn.mit.edu` or `API_BASE_URL=http://localhost:8063`
 
 ## Requirements
 
-For successful execution and correct output, ensure the [MIT Open's API](https://mit-open-rc.odl.mit.edu//api/v1/courses/?platform=ocw) contains the following fields:
+For successful execution and correct output, ensure the [MIT Learn's API](https://api.rc.learn.mit.edu/api/v1/courses/?platform=ocw) contains the following fields:
 
 `title`, `url`, `runs: level`, `description`, `topics`, `runs: instructors`, `runs: semester`, `runs: year`, `course_feature`
 Additionally, the `mapping_files` should be up-to-date. If new topics are added in OCW without corresponding mappings in `ocw_oer_export/mapping_files/ocw_topic_to_oer_subject.csv`, this will lead to `null` entries for those topics in the CSV (`CR_SUBJECT`). In addition to that, make sure `fm_keywords_exports.csv` is also present.

--- a/ocw_oer_export/config.py
+++ b/ocw_oer_export/config.py
@@ -7,5 +7,5 @@ from dotenv import load_dotenv
 
 load_dotenv()
 
-API_BASE_URL = os.getenv("API_BASE_URL", "https://api.mitopen.odl.mit.edu")
+API_BASE_URL = os.getenv("API_BASE_URL", "https://api.learn.mit.edu")
 API_URL = f"{API_BASE_URL}/api/v1/courses/?platform=ocw"

--- a/ocw_oer_export/utilities/normalize_course_url.py
+++ b/ocw_oer_export/utilities/normalize_course_url.py
@@ -1,5 +1,5 @@
 """
-Module for normalizing OCW FM export course URLs to the format comparable with MIT Open's API.
+Module for normalizing OCW FM export course URLs to the format comparable with MIT Learn's API.
 """
 
 
@@ -8,7 +8,7 @@ def normalize_course_url(url):
     The OCW FM export format includes the department name:
     'ocw.mit.edu/courses/department_name/course_metadata'
 
-    This function removes the 'department_name' to match the MIT Open's API format:
+    This function removes the 'department_name' to match the MIT Learn's API format:
     'ocw.mit.edu/courses/course_metadata'
 
     Example:


### PR DESCRIPTION
### What are the relevant tickets?
Closes https://github.com/mitodl/hq/issues/5173

### Description (What does it do?)
This PR updates the API `config` and all project references from `MIT Open` to `MIT Learn`.


### How can this be tested?
Checkout to this branch.
1. `docker compose build`
2. `docker compose run --rm app`
3. Locate the file `private/output/ocw_oer_export.csv` and see it has OCW courses data.
