### PR TITLE
Add --target $GITHUB_SHA to ensure latest commit is used for GitHub releases

### DIFF
--- a/.github/workflows/weekly_csv_release.yml
+++ b/.github/workflows/weekly_csv_release.yml
@@ -3,8 +3,11 @@ on:
   push:
       branches:
       - main
-  schedule:
-      - cron: '0 10 * * 1' # Every Monday at 10AM
+  pull_request:
+      branches:
+      - feature/add-target-sha-to-release
+  # schedule:
+  #     - cron: '0 10 * * 1' # Every Monday at 10AM
 
 jobs:
   generate_and_release_csv:

--- a/.github/workflows/weekly_csv_release.yml
+++ b/.github/workflows/weekly_csv_release.yml
@@ -3,9 +3,8 @@ on:
   push:
       branches:
       - main
-  pull_request:
-  # schedule:
-  #     - cron: '0 10 * * 1' # Every Monday at 10AM
+  schedule:
+      - cron: '0 10 * * 1' # Every Monday at 10AM
 
 jobs:
   generate_and_release_csv:

--- a/.github/workflows/weekly_csv_release.yml
+++ b/.github/workflows/weekly_csv_release.yml
@@ -95,4 +95,4 @@ jobs:
             fi
             gh release create $LATEST_RELEASE_NAME ./private/output/ocw_oer_export.csv -t "Latest Release" -n "This release was created for CSV weekly output. This release contains the most recent CSV. Please get the CSV file from the Assets listed below." --latest --target $GITHUB_SHA
           env:
-            GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+            GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/weekly_csv_release.yml
+++ b/.github/workflows/weekly_csv_release.yml
@@ -88,6 +88,6 @@ jobs:
             then
                 gh release delete $LATEST_RELEASE_NAME
             fi
-            gh release create $LATEST_RELEASE_NAME ./private/output/ocw_oer_export.csv -t "Latest Release" -n "This release was created for CSV weekly output. This release contains the most recent CSV. Please get the CSV file from the Assets listed below." --latest
+            gh release create $LATEST_RELEASE_NAME ./private/output/ocw_oer_export.csv -t "Latest Release" -n "This release was created for CSV weekly output. This release contains the most recent CSV. Please get the CSV file from the Assets listed below." --latest --target $GITHUB_SHA
           env:
             GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/weekly_csv_release.yml
+++ b/.github/workflows/weekly_csv_release.yml
@@ -88,6 +88,11 @@ jobs:
             if gh release view $LATEST_RELEASE_NAME
             then
                 gh release delete $LATEST_RELEASE_NAME
+                if git rev-parse $LATEST_RELEASE_NAME
+                then
+                  git tag -d $LATEST_RELEASE_NAME
+                  git push --delete origin $LATEST_RELEASE_NAME
+                fi
             fi
             gh release create $LATEST_RELEASE_NAME ./private/output/ocw_oer_export.csv -t "Latest Release" -n "This release was created for CSV weekly output. This release contains the most recent CSV. Please get the CSV file from the Assets listed below." --latest --target $GITHUB_SHA
           env:

--- a/.github/workflows/weekly_csv_release.yml
+++ b/.github/workflows/weekly_csv_release.yml
@@ -78,7 +78,7 @@ jobs:
           run:
             |
             echo "Creating release: $TAG_NAME"
-            gh release create "${{ env.TAG_NAME }}" ./private/output/ocw_oer_export.csv -p -t "${{ env.RELEASE_TITLE }}" -n "This release was created for CSV weekly output. Please get the CSV file from the Assets listed below."
+            gh release create "${{ env.TAG_NAME }}" ./private/output/ocw_oer_export.csv -p -t "${{ env.RELEASE_TITLE }}" -n "This release was created for CSV weekly output. Please get the CSV file from the Assets listed below." --target $GITHUB_SHA
           env:
             GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/weekly_csv_release.yml
+++ b/.github/workflows/weekly_csv_release.yml
@@ -4,8 +4,6 @@ on:
       branches:
       - main
   pull_request:
-      branches:
-      - feature/add-target-sha-to-release
   # schedule:
   #     - cron: '0 10 * * 1' # Every Monday at 10AM
 


### PR DESCRIPTION
### What are the relevant tickets?
N/A
Relevant message on Slack: https://mitodl.slack.com/archives/GQ89D0Z5M/p1727667900909399

### Description (What does it do?)
This PR ensures that both the timestamp and `latest` releases are tied to the correct commit, and adds necessary checks to handle the deletion of existing `latest` tag and releases before creating new ones.

### How can this be tested?
Check the source code time under assets in the recent releases: https://github.com/mitodl/ocw_oer_export/releases which were triggered by testing of this PR (by adding `on: pull_request`)
For latest release:
https://github.com/mitodl/ocw_oer_export/releases/tag/latest
